### PR TITLE
Add Discord standup bot

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: python bot.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Cosmik-workflows
+
+This repo contains a simple Discord bot that forwards `/standup` updates to a Notion database. It is ready to deploy on [Render](https://render.com).
+
+## Deployment
+
+1. Set the environment variables `DISCORD_TOKEN`, `NOTION_TOKEN`, and `NOTION_DATABASE_ID` in your Render service.
+2. Deploy using the provided `Procfile` which runs `python bot.py`.
+
+The bot registers a `/standup` slash command. When invoked, it saves the provided text to Notion as an entry named `updates by <discord-username>` in the target database under the `Notes & Updates` field.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,49 @@
+import os
+import discord
+from discord import app_commands
+import requests
+
+NOTION_TOKEN = os.getenv("NOTION_TOKEN")
+NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+
+class StandupBot(discord.Client):
+    def __init__(self):
+        intents = discord.Intents.default()
+        super().__init__(intents=intents)
+        self.tree = app_commands.CommandTree(self)
+
+    async def setup_hook(self):
+        @self.tree.command(name="standup", description="Submit standup notes")
+        @app_commands.describe(text="Your notes")
+        async def standup(interaction: discord.Interaction, text: str):
+            await interaction.response.defer(ephemeral=True)
+            create_notion_entry(interaction.user, text)
+            await interaction.followup.send("Standup saved to Notion!", ephemeral=True)
+
+        await self.tree.sync()
+
+def create_notion_entry(user: discord.abc.User, text: str) -> None:
+    url = "https://api.notion.com/v1/pages"
+    headers = {
+        "Authorization": f"Bearer {NOTION_TOKEN}",
+        "Notion-Version": "2022-06-28",
+        "Content-Type": "application/json",
+    }
+    data = {
+        "parent": {"database_id": NOTION_DATABASE_ID},
+        "properties": {
+            "Name": {"title": [{"text": {"content": f"updates by {user.name}"}}]},
+            "Notes & Updates": {
+                "rich_text": [{"text": {"content": text}}]
+            },
+        },
+    }
+    requests.post(url, headers=headers, json=data)
+
+def main() -> None:
+    bot = StandupBot()
+    bot.run(DISCORD_TOKEN)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py==2.3.2
+requests


### PR DESCRIPTION
## Summary
- implement a Discord bot that registers `/standup` and posts updates to Notion
- provide `requirements.txt` and `Procfile` for Render deploy
- document environment variables in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_687cb3a08ed88332b0af79e3515ed08a