### PR TITLE
Support multi-field Notion updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,11 @@ This repo contains a simple Discord bot that forwards `/standup` updates to a No
 1. Set the environment variables `DISCORD_TOKEN`, `NOTION_TOKEN`, and `NOTION_DATABASE_ID` in your Render service.
 2. Deploy using the provided `Procfile` which runs `python bot.py`.
 
-The bot registers a `/standup` slash command. When invoked, it saves the provided text to Notion and echoes the submitted update in the channel so that everyone can see it.
+The bot registers a `/standup` slash command. When invoked, it displays a modal asking for the following fields:
+
+- **In Progress Today** – work in progress today
+- **Planned Next** – what you will do next
+- **Notes & Updates** – any notes or updates
+- **Availability** – your availability today
+
+After submitting, the responses are saved to Notion and echoed back to the channel.

--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,7 @@
 import os
 import discord
 from discord import app_commands
+from discord.ui import TextInput, Modal
 import requests
 
 NOTION_TOKEN = os.getenv("NOTION_TOKEN")
@@ -15,17 +16,73 @@ class StandupBot(discord.Client):
 
     async def setup_hook(self):
         @self.tree.command(name="standup", description="Submit an update")
-        @app_commands.describe(text="Your update")
-        async def standup(interaction: discord.Interaction, text: str):
-            await interaction.response.defer()
-            create_notion_entry(interaction.user, text)
-            await interaction.followup.send(
-                f"{interaction.user.mention} posted an update: {text}"
-            )
+        async def standup(interaction: discord.Interaction):
+            modal = StandupModal(interaction.user)
+            await interaction.response.send_modal(modal)
 
         await self.tree.sync()
 
-def create_notion_entry(user: discord.abc.User, text: str) -> None:
+class StandupModal(Modal):
+    def __init__(self, user: discord.abc.User):
+        super().__init__(title="Standup Update")
+        self.user = user
+
+        self.in_progress_today = TextInput(
+            label="In Progress Today",
+            placeholder="work in progress today",
+            style=discord.TextStyle.paragraph,
+            required=False,
+        )
+
+        self.planned_next = TextInput(
+            label="Planned Next",
+            placeholder="What I will do next",
+            style=discord.TextStyle.paragraph,
+            required=False,
+        )
+
+        self.notes_updates = TextInput(
+            label="Notes & Updates",
+            placeholder="Any notes or updates",
+            style=discord.TextStyle.paragraph,
+            required=False,
+        )
+
+        self.availability = TextInput(
+            label="Availability",
+            placeholder="What is my availability today",
+            style=discord.TextStyle.short,
+            required=False,
+        )
+
+        self.add_item(self.in_progress_today)
+        self.add_item(self.planned_next)
+        self.add_item(self.notes_updates)
+        self.add_item(self.availability)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        create_notion_entry(
+            self.user,
+            self.in_progress_today.value,
+            self.planned_next.value,
+            self.notes_updates.value,
+            self.availability.value,
+        )
+        await interaction.response.send_message(
+            f"{self.user.mention} posted an update:\n"
+            f"In Progress Today: {self.in_progress_today.value}\n"
+            f"Planned Next: {self.planned_next.value}\n"
+            f"Notes & Updates: {self.notes_updates.value}\n"
+            f"Availability: {self.availability.value}"
+        )
+
+def create_notion_entry(
+    user: discord.abc.User,
+    in_progress_today: str,
+    planned_next: str,
+    notes_updates: str,
+    availability: str,
+) -> None:
     url = "https://api.notion.com/v1/pages"
     headers = {
         "Authorization": f"Bearer {NOTION_TOKEN}",
@@ -36,8 +93,17 @@ def create_notion_entry(user: discord.abc.User, text: str) -> None:
         "parent": {"database_id": NOTION_DATABASE_ID},
         "properties": {
             "Name": {"title": [{"text": {"content": f"updates by {user.name}"}}]},
+            "In Progress Today": {
+                "rich_text": [{"text": {"content": in_progress_today}}]
+            },
+            "Planned Next": {
+                "rich_text": [{"text": {"content": planned_next}}]
+            },
             "Notes & Updates": {
-                "rich_text": [{"text": {"content": text}}]
+                "rich_text": [{"text": {"content": notes_updates}}]
+            },
+            "Availability": {
+                "rich_text": [{"text": {"content": availability}}]
             },
         },
     }


### PR DESCRIPTION
## Summary
- collect standup updates via Discord modal
- map In Progress Today, Planned Next, Notes & Updates and Availability to Notion
- document new workflow in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68839a7ee6a88332b16e2854c473b65c